### PR TITLE
Memleak

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ See below instructions for downloading the source code.
 Run the module from the Python shell with:
 ```
 import rivers2stratigraphy
-rivers2stratigraphy.run()
 ```
 
 Alternatively, run the module with provided script:
@@ -72,10 +71,12 @@ python3 <path-to-installation>/run_rivers2stratigraphy.py
 
 Note that this may throw an error on closing the window, but this is not a problem to functionality.
 
+<!--
 Or you can run the module directly:
 ```
 
 ```
+-->
 
 Please [open an issue](https://github.com/amoodie/rivers2stratigraphy/issues) if you encounter any additional error messages! 
 Please include 1) operating system, 2) installation method, and 3) copy-paste the error.

--- a/rivers2stratigraphy/channel.py
+++ b/rivers2stratigraphy/channel.py
@@ -10,7 +10,7 @@ from . import geom, sedtrans, utils
 
 class Channel(object):
     # make everything into a float16
-    def __init__(self, x_centi = 0, Bast = 0, age = 0, avul_num = 0, sm = None):
+    def __init__(self, x_centi = 0, Bast = 0, age = 0, avul_num = 0, sm = None, parent=None):
         
         self.sm = sm
         self.avul_num = avul_num
@@ -18,10 +18,15 @@ class Channel(object):
         self.avul_timer = 0
         self.Ta = self.sm.Ta
         self.age = age
+        self.parent = parent
             
         self.state = State(new_channel = True, dxdt =0, Bast = Bast, age = 0, sm = self.sm)
         self.stateList = [self.state]
-        self.geom = Rectangle(self.state.ll, self.state.Bc, self.state.H)
+        self.patches = [Rectangle(self.state.ll, self.state.Bc, self.state.H)]
+
+        # onechannel = [Rectangle(self.state.ll, self.state.Bc, self.state.H)]
+        # self.activeChannelPatchCollection = PatchCollection(onechannel)
+        
         # self.geom = PatchCollection(patch)
 
     def timestep(self):
@@ -45,11 +50,18 @@ class Channel(object):
         '''
         geometry of the body to be plotted
         '''
-        patches = [Rectangle(s.ll, s.Bc, s.H) for s in iter(self.stateList)]
-        patchcollection = PatchCollection(patches)
-        self.geom = patchcollection
-        del patches, patchcollection
-        return self.geom
+        
+        # self.patches = [Rectangle(s.ll, s.Bc, s.H) for s in iter(self.stateList)]
+        # self.parent.activeChannelPatchCollection.set_paths(self.patches)
+        pass
+
+        # patchcollection = PatchCollection(patches)
+        # self.activeChannelPatchCollection = self.activeChannelPatchCollection.set_paths(patches)
+        
+        # self.activeChannelPatchCollection.set_paths(patches)
+        
+        # del patches, patchcollection
+        # return self.geom
 
     def migrate(self):
         dxdt = (self.sm.dxdtstd * (np.random.randn()) )
@@ -107,7 +119,7 @@ class ChannelBody(object):
         self.polygonXs = self.polygonAsArray[:,0]
         self.polygonYs = self.polygonAsArray[:,1]
 
-        self.polygonPatch = Polygon(self.polygonAsArray)
+        self.patch = Polygon(self.polygonAsArray)
 
         # get all the "means" of variables for coloring values
         self.age = channel.age
@@ -120,10 +132,10 @@ class ChannelBody(object):
         self.polygonYs -= dz
         # self.y_upper = self.polygonYs.max()
         xsys = np.column_stack((self.polygonXs, self.polygonYs))
-        self.polygonPatch.set_xy(xsys)
+        self.patch.set_xy(xsys)
 
     def get_patch(self):
-        return self.polygonPatch
+        return self.patch
 
     def rect2box(self, ll, Bc, H):
         box = sg.box(ll[0], ll[1], 

--- a/rivers2stratigraphy/test.py
+++ b/rivers2stratigraphy/test.py
@@ -1,0 +1,44 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.animation as anm
+import matplotlib.collections as clt
+
+fig, ax = plt.subplots(1,1,figsize=(7,7))
+
+ax.set_xlim(-1,1)
+ax.set_ylim(-1,1)
+
+n_of_particles = 30
+frames = 10
+
+radius = 0.05
+x = 0.5*np.random.randn(frames,n_of_particles)
+y = 0.5*np.random.randn(frames,n_of_particles)
+z = 0.5*np.random.randn(frames,n_of_particles)
+
+patches = []
+for p in range(n_of_particles):
+    circle = plt.Circle((x[0,p], y[0,p]), radius)
+    patches.append(circle)
+
+collection = clt.PatchCollection(patches, cmap=plt.cm.jet, alpha=0.4)
+collection.set_array(z[0,:])
+collection.set_clim([-1, 1])
+fig.colorbar(collection)
+
+ax.add_collection(collection)
+
+def animate(frame):
+    patches = []
+    for p in range(n_of_particles):
+        circle = plt.Circle((x[frame,p], y[frame,p]), radius)
+        patches.append(circle)
+
+    print(patches, '\n')
+
+    collection.set_paths(patches)
+    collection.set_array(z[frame,:])
+
+anim = anm.FuncAnimation(fig, animate,
+                               frames=10, interval=100, blit=False)
+plt.show()


### PR DESCRIPTION
resolved the blight of a memory leak issue (#1). 

Basically the issue was that new `PatchCollection` objects were being created during each iteration of the model, and not being garbage collected because they maintained reference (somehow? not sure?). The solution was to create and add the patch only once and then use the (largely undocumented) method of `PatchCollection.set_paths(patches)` to update the patches to draw, thereby only having one instance of the `PatchCollection`.

closes #1 