### PR TITLE
Union

### DIFF
--- a/rivers2stratigraphy/channel.py
+++ b/rivers2stratigraphy/channel.py
@@ -18,7 +18,7 @@ class ActiveChannel(object):
         self.age = age
         self.parent = parent
             
-        self.state = State(new_channel = True, dxdt =0, Bast = Bast, age = 0, sm = self.sm)
+        self.state = ChannelState(new_channel = True, dxdt =0, Bast = Bast, age = 0, sm = self.sm)
         self.stateList = [self.state]
         self.patches = [Rectangle(self.state.ll, self.state.Bc, self.state.H)]
 
@@ -29,7 +29,7 @@ class ActiveChannel(object):
         self.subside()
         x_cent, dxdt = self.migrate()
 
-        self.state = State(x_cent = x_cent, dxdt = dxdt,
+        self.state = ChannelState(x_cent = x_cent, dxdt = dxdt,
                            Bast = self.state0.Bast, sm = self.sm)
         self.stateList.append(self.state)
 
@@ -131,7 +131,7 @@ class ChannelBody(object):
         return box
 
 
-class State(object):
+class ChannelState(object):
 
     def __init__(self, new_channel = False, x_cent = 0, dxdt = 0, Bast = 0, age = 0, sm = None):
 

--- a/rivers2stratigraphy/channel.py
+++ b/rivers2stratigraphy/channel.py
@@ -85,7 +85,7 @@ class ChannelBody(object):
                 stateSeriesConvexHull.append(seriesUnionTemp.convex_hull)
             stateUnion = so.cascaded_union(stateSeriesConvexHull)
             self.polygonAsArray = np.asarray(stateUnion.exterior)
-        else:
+        elif self.conversionFlag == "diff":
             # different methods for polygon and multipolygon
             stateUnion = so.cascaded_union(stateBoxes) # try so.cascaded_union(stateBoxes[::2]) for speed?
             # if type is polygon
@@ -99,6 +99,8 @@ class ChannelBody(object):
                     stateSeriesConvexHull.append(seriesUnionTemp.convex_hull)
                 stateUnion = so.cascaded_union(stateSeriesConvexHull)
                 self.polygonAsArray = np.asarray(stateUnion.exterior)
+        else:
+            raise ValueError("invalid conversionFlag in ChannelBody")
 
         
 

--- a/rivers2stratigraphy/gui.py
+++ b/rivers2stratigraphy/gui.py
@@ -19,7 +19,6 @@ import matplotlib.animation as animation
 
 from .strat import Strat
 from .slider_manager import SliderManager
-from .channel import ActiveChannel, State, ChannelBody
 from . import geom, sedtrans, utils
 
 

--- a/rivers2stratigraphy/strat.py
+++ b/rivers2stratigraphy/strat.py
@@ -6,7 +6,7 @@ import matplotlib.animation as animation
 import shapely.geometry as sg
 import shapely.ops as so
 
-from .channel import ActiveChannel, State, ChannelBody
+from .channel import ActiveChannel, ChannelState, ChannelBody
 from . import utils
 
 class Strat(object):

--- a/run_rivers2stratigraphy.py
+++ b/run_rivers2stratigraphy.py
@@ -1,5 +1,5 @@
 import rivers2stratigraphy
 
-print('launching activity...')
+print('launching activity...\n')
 
 rivers2stratigraphy.run()


### PR DESCRIPTION
change method for conversion of ActiveChannel to ChannelBody. In this new approach a series of convex hulls are made between every two ChannelStates and then the union of the new hulls is made. This ensures a single part polygon and make for "realistic" looking channel bodies (i.e., smoothed).

Also cleaned up some code, and changed `channel.State` to `channel.ChannelState` for clarity across scripts.